### PR TITLE
Fix for case-sensitive file systems (Linux)

### DIFF
--- a/DuperyPatches.cs
+++ b/DuperyPatches.cs
@@ -4,6 +4,7 @@ using KMod;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace Dupery
 {
@@ -58,7 +59,24 @@ namespace Dupery
                     continue;
 
                 string personalitiesFilePath = Path.Combine(mod.content_source.GetRoot(), PersonalityManager.PERSONALITIES_FILE_NAME);
-                if (File.Exists(personalitiesFilePath))
+
+                if (!File.Exists(personalitiesFilePath)) {
+                    personalitiesFilePath = null;
+
+                    string[] files = Directory.GetFiles(mod.content_source.GetRoot());
+                    Regex rx = new Regex(@"personalities\.json", RegexOptions.IgnoreCase);
+                    
+                    foreach (string file in files)
+                    {
+                        Match curr_rx = rx.Match(Path.GetFileName(file));
+                        if (curr_rx.Success) {
+                            personalitiesFilePath = file;
+                            break;
+                        }
+                    }
+                }
+                
+                if (personalitiesFilePath != null && File.Exists(personalitiesFilePath))
                 {
                     Logger.Log($"Found {PersonalityManager.PERSONALITIES_FILE_NAME} file belonging to mod {mod.title}, attempting to import personalities and accessories...");
 


### PR DESCRIPTION
# Motivation
This is a solution to issue #9.

I've tried to get Dupery to run with the example mod [Print Cassady](https://github.com/Barleytree/Example-Character-Mod) on Linux.

It turns out that due to the `personalities.json` not being called `PERSONALITIES.json` Dupery doesn't detect it when running on systems with case-sensitive file systems (for example **Linux**) where such things do make a difference.

While the problem comes from mods not naming their _PERSONALITIES.json_ correctly, I find this issue to be more easily fixed in Dupery. 
Otherwise every mod maker with that issues would have to change their file name without it making issues to most (windows) users.

# Changes
If the _PERSONALITIES.json_ is not found as usual, instead of giving up, a search with a case-insensitive regex is started in the top-level of the mod folder.

The first match is then used as the expected _PERSONALITIES.json_

# Testing
I've tested this by creating new games in ONI and checking that Cassidy appears in-game as well as in the _Player.log_.

This change works for me on Linux and Windows without issue and fixes issue #9.